### PR TITLE
Adds integration tests via test-kitchen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.kitchen/
+.kitchen.local.yml
+Gemfile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,3 +26,5 @@ provisioner:
   # `ansible_push` does honor this option, though:
   chef_bootstrap_url: false
 
+verifier:
+  name: inspec

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,28 @@
+---
+driver:
+  name: vagrant
+
+platforms:
+  - name: ubuntu/trusty64
+    driver:
+      box: ubuntu/trusty64
+
+  - name: debian/jessie64
+    driver:
+      box: debian/jessie64
+
+suites:
+  - name: default
+
+provisioner:
+  name: ansible_push
+  playbook: test/integration/default/default.yml
+  verbose: vv
+  diff: yes
+  # The `ansible_playbook` provisioner supports these options,
+  # but `ansible_push` does not.
+  require_ruby_for_busser: false
+  require_chef_for_busser: false
+  # `ansible_push` does honor this option, though:
+  chef_bootstrap_url: false
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# encoding: utf-8
+
+source 'https://rubygems.org'
+
+gem 'test-kitchen'
+gem 'kitchen-ansiblepush'
+gem 'kitchen-vagrant'
+gem 'kitchen-inspec'

--- a/README.md
+++ b/README.md
@@ -44,3 +44,12 @@ Use the role in a playbook like this:
   roles:
     - riemann-server
 ```
+
+# Running the tests
+
+Requires [test-kitchen](https://github.com/test-kitchen/test-kitchen).
+
+```
+bundle install
+bundle exec kitchen test
+```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 riemann_use_tarball: false
 riemann_use_package: true
-riemann_use_logstash: true
+riemann_use_logstash: false
 
 riemann_download_dir: /usr/local/src
 riemann_version:      0.2.10
@@ -27,3 +27,6 @@ riemann_udp_port: 5555
 riemann_ws_port:  5556
 riemann_repl_port: 5557
 riemann_sse_port: 5558
+
+# Only used if `riemann_use_logstash: true`.
+riemann_logstash_conf_dir: /etc/logstash/conf.d

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ riemann_use_package: true
 riemann_use_logstash: true
 
 riemann_download_dir: /usr/local/src
-riemann_version:      0.2.8
+riemann_version:      0.2.10
 
 riemann_user: riemann
 riemann_uid:   206

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,10 +1,14 @@
 ---
-
 - name: Ensure Riemann download directory exists
-  file: path={{ riemann_download_dir }} state=directory owner=root group=root mode=0755
+  file:
+    path: "{{ riemann_download_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
 
 - include: install_from_tarball.yml
   when: riemann_use_tarball
-  
+
 - include: install_from_package.yml
   when: riemann_use_package

--- a/tasks/install_from_package.yml
+++ b/tasks/install_from_package.yml
@@ -1,26 +1,49 @@
 ---
-
 - name: Download Riemann release
   when: ansible_os_family == "Debian"
-  get_url: url="https://aphyr.com/riemann/riemann_{{ riemann_version }}_all.deb" dest="{{ riemann_download_dir }}/riemann_{{ riemann_version }}_all.deb"
+  get_url:
+    url: "https://aphyr.com/riemann/riemann_{{ riemann_version }}_all.deb"
+    dest: "{{ riemann_download_dir }}/riemann_{{ riemann_version }}_all.deb"
 
 - name: Install Riemann release
   when: ansible_os_family == "Debian"
-  apt: deb="{{ riemann_download_dir }}/riemann_{{ riemann_version }}_all.deb" state=installed
+  apt:
+    deb: "{{ riemann_download_dir }}/riemann_{{ riemann_version }}_all.deb"
+    state: installed
 
 - name: Download & install Riemann release
   when: ansible_os_family == "RedHat"
-  yum: name="https://aphyr.com/riemann/riemann-{{ riemann_version }}-1.noarch.rpm" state=present
+  yum:
+    name: "https://aphyr.com/riemann/riemann-{{ riemann_version }}-1.noarch.rpm"
+    state: present
 
 - name: Create configuration directory
-  file: path={{ riemann_conf_dir }}/conf.d state=directory recurse=yes owner=root group=root mode=0755
+  file:
+    path: "{{ riemann_conf_dir }}/conf.d"
+    state: directory
+    recurse: yes
+    owner: root
+    group: root
+    mode: "0755"
 
 - name: Create configuration file
-  template: src=riemann.config.j2 dest={{ riemann_conf_dir }}/riemann.config owner=root group=root mode=0644
+  template:
+    src: riemann.config.j2
+    dest: "{{ riemann_conf_dir }}/riemann.config"
+    owner: root
+    group: root
+    mode: "0644"
 
 - name: Create log directory
-  file: path={{ riemann_log_dir }} state=directory owner={{ riemann_user }} group={{ riemann_group }} mode=0755
+  file:
+    path: "{{ riemann_log_dir }}"
+    state: directory
+    owner: "{{ riemann_user }}"
+    group: "{{ riemann_group }}"
+    mode: "0755"
 
 - name: Start Riemann server
-  service: name=riemann state={{ riemann_state }} enabled={{ riemann_enable }}
-  
+  service:
+    name: riemann
+    state: "{{ riemann_state }}"
+    enabled: "{{ riemann_enable }}"

--- a/tasks/install_from_tarball.yml
+++ b/tasks/install_from_tarball.yml
@@ -1,26 +1,49 @@
 ---
-
 - name: Download Riemann release
-  get_url: url="https://aphyr.com/riemann/riemann-{{ riemann_version }}.tar.bz2" dest="{{ riemann_download_dir }}/riemann-{{ riemann_basename }}.tar.bz2"
+  get_url:
+    url: "https://aphyr.com/riemann/riemann-{{ riemann_version }}.tar.bz2"
+    dest: "{{ riemann_download_dir }}/riemann-{{ riemann_basename }}.tar.bz2"
 
 - name: Unarchive Riemann release
-  unarchive: src="{{ riemann_download_dir }}/riemann-{{ riemann_version }}.tar.bz2" dest="{{ riemann_root }}" creates="{{ riemann_root }}/riemann-{{ riemann_version }}" copy=no owner=root group=root
+  unarchive:
+    src: "{{ riemann_download_dir }}/riemann-{{ riemann_version }}.tar.bz2"
+    dest: "{{ riemann_root }}"
+    creates: "{{ riemann_root }}/riemann-{{ riemann_version }}"
+    copy: no
+    owner: root
+    group: root
 
 - name: Link Riemann release
-  file: state=link path={{ riemann_home_dir }} src="{{ riemann_root }}/riemann-{{ riemann_version }}"
+  file:
+    state: link
+    path: "{{ riemann_home_dir }}"
+    src: "{{ riemann_root }}/riemann-{{ riemann_version }}"
 
 - name: Create user group
-  group: name={{ riemann_group }} gid={{ riemann_gid }}
+  group:
+    name: "{{ riemann_group }}"
+    gid: "{{ riemann_gid }}"
   tags:
     - groups
 
 - name: Create user
-  user: name={{ riemann_user }} uid={{ riemann_uid }} comment="Riemann" group={{ riemann_group }} shell=/bin/false home={{ riemann_user_dir }}
+  user:
+    name: "{{ riemann_user }}"
+    uid: "{{ riemann_uid }}"
+    comment: "Riemann"
+    group: "{{ riemann_group }}"
+    shell: /bin/false
+    home: "{{ riemann_user_dir }}"
   tags:
     - users
-    
+
 - name: Create upstart configuration file
-  template: src=upstart.conf.j2 dest=/etc/init/riemann.conf owner=root group=root mode=0644
+  template:
+    src: upstart.conf.j2
+    dest: /etc/init/riemann.conf
+    owner: root
+    group: root
+    mode: 0644
   when: ansible_os_family == "Debian"
   notify:
     - restart riemann

--- a/tasks/logstash.yml
+++ b/tasks/logstash.yml
@@ -2,7 +2,7 @@
 - name: Installing logstash configuration file
   template:
     src: logstash.conf.j2
-    dest: "{{ logstash_conf_dir }}/riemann.conf"
+    dest: "{{ riemann_logstash_conf_dir }}/riemann.conf"
     owner: root
     group: root
     mode: 0644

--- a/tasks/logstash.yml
+++ b/tasks/logstash.yml
@@ -1,6 +1,10 @@
 ---
-
 - name: Installing logstash configuration file
-  template: src=logstash.conf.j2 dest="{{ logstash_conf_dir }}/riemann.conf" owner=root group=root mode=0644
+  template:
+    src: logstash.conf.j2
+    dest: "{{ logstash_conf_dir }}/riemann.conf"
+    owner: root
+    group: root
+    mode: 0644
   notify:
     - restart logstash

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,8 @@
 ---
-
 - include: install.yml
   tags:
     - riemann-server
-    
+
 - include: logstash.yml
   when: riemann_use_logstash
   tags:

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -1,0 +1,6 @@
+---
+- name: Test installation of riemann server role.
+  hosts: all
+  become: yes
+  roles:
+    - ../../../../riemann-server-ansible-role

--- a/test/integration/default/riemann_server_spec.rb
+++ b/test/integration/default/riemann_server_spec.rb
@@ -10,4 +10,32 @@ end
 
 describe user('riemann') do
   it { should exist }
+  its('group') { should eq 'riemann' }
+  its('shell') { should eq '/bin/false' }
+  its('home') { should eq '/usr/share/riemann' }
+end
+
+describe file('/etc/logstash/conf.d') do
+  it { should_not exist }
+end
+
+riemann_directories = %w(
+  /usr/share/riemann
+  /etc/riemann
+  /var/log/riemann
+)
+riemann_directories.each do |dir|
+  describe file(dir) do
+    it { should exist }
+    it { should be_directory }
+  end
+end
+
+describe file('/etc/riemann/riemann.config') do
+  it { should exist }
+  its('owner') { should eq "root" }
+  its('group') { should eq "root" }
+  its('mode') { should eq 0644 }
+
+  its('content') { should match "(tcp-server {:host host :port 5555})" }
 end

--- a/test/integration/default/riemann_server_spec.rb
+++ b/test/integration/default/riemann_server_spec.rb
@@ -1,0 +1,13 @@
+# use basic tests
+describe package('riemann') do
+  it { should be_installed }
+end
+
+describe service('riemann') do
+  it { should be_enabled }
+  it { should be_installed }
+end
+
+describe user('riemann') do
+  it { should exist }
+end


### PR DESCRIPTION
To run:

```
bundle install
bundle exec kitchen test
```

Runs against Debian 8 and Ubuntu 14.04, without errors. Made some minor adjustments to the config, notably disabling logstash by default, since there was an undefined var `logstash_conf_dir` (which the tests caught!). 

Depends on #2, which should be merged first. :sheep:
